### PR TITLE
Constructor update for Ptensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+cnine.log
+python/build/
+python/src/ptens.egg-info/
+python/src/ptens/__pycache__/
+python/src/ptens_base.**

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,6 +8,14 @@ from os.path import splitext
 from os.path import basename
 from glob import glob
 
+def interpret_bool_string(string:str|bool, _true_values:tuple[str] = ("TRUE", "ON"), _false_values:tuple[str] = ("FAlSE", "OFF")):
+    if isinstance(string, bool):
+        return string
+    if string.strip().upper() in _true_values:
+        return True
+    if string.strip().upper() in _false_values:
+        return False
+    raise ValueError(f"String {string} cannot be interpreted as True or False. Any upper/lower-case version of {_true_values} is True, {_false_values} is False. {string} was neither.")
 
 def main():
 
@@ -15,14 +23,14 @@ def main():
     # os.environ['CUDA_HOME']='/usr/local/cuda'
     #os.environ["CC"] = "clang"
 
-    compile_with_cuda = False  
-    # compile_with_cuda = True
+    # compile_with_cuda = False
+    compile_with_cuda = interpret_bool_string(os.environ.get("WITH_CUDA", True))
 
     copy_warnings = False
     torch_convert_warnings = False
 
     # ------------------------------------------------------------------------------------------------------------
-    
+
     #if 'CUDAHOME' in os.environ:
         #print("CUDA found at "+os.environ['CUDAHOME'])
 
@@ -112,8 +120,8 @@ def main():
     if compile_with_cuda:
         ext_modules = [CUDAExtension('ptens_base', [
             '../../cnine/include/Cnine_base.cu',
-            '../../cnine/cuda/TensorView_accumulators.cu',
-            '../../cnine/cuda/BasicCtensorProducts.cu',
+            #'../../cnine/cuda/TensorView_accumulators.cu',
+            #'../../cnine/cuda/BasicCtensorProducts.cu',
             '../../cnine/cuda/RtensorUtils.cu',
             '../../cnine/cuda/TensorView_add.cu',
             '../../cnine/cuda/TensorView_assign.cu',
@@ -158,4 +166,3 @@ def main():
 if __name__ == "__main__":
     main()
     print("Compilation finished:", time.ctime(time.time()))
-

--- a/python/src/ptens/ptensor.py
+++ b/python/src/ptens/ptensor.py
@@ -1,23 +1,39 @@
 #
-# This file is part of ptens, a C++/CUDA library for permutation 
-# equivariant message passing. 
-#  
+# This file is part of ptens, a C++/CUDA library for permutation
+# equivariant message passing.
+#
 # Copyright (c) 2023, Imre Risi Kondor
 #
-# This source code file is subject to the terms of the noncommercial 
-# license distributed with cnine in the file LICENSE.TXT. Commercial 
-# use is prohibited. All redistributed versions of this file (in 
-# original or modified form) must retain this copyright notice and 
-# must be accompanied by a verbatim copy of the license. 
+# This source code file is subject to the terms of the noncommercial
+# license distributed with cnine in the file LICENSE.TXT. Commercial
+# use is prohibited. All redistributed versions of this file (in
+# original or modified form) must retain this copyright notice and
+# must be accompanied by a verbatim copy of the license.
 #
 #
 
 import torch
-import ptens_base as pb 
-
+import ptens_base as pb
 
 class ptensor(torch.Tensor):
 
+    def __new__(cls, atoms:list, data:torch.Tensor | torch.Size, *args, **kwargs):
+        # We write a new __new__ function here, since the signature now includes atoms.
+        # But we need __new__ since it handles the memory allocations, potentially on the GPU.
+        return torch.Tensor.__new__(cls, data, *args, **kwargs)
+
+    def __init__(self, atoms:list, data:torch.Tensor | torch.Size, *args, **kwargs):
+        """
+        Instantiate a generic P-Tensor.
+        It requires `atoms` and a tensor `data` structure to be passed to the tensor.
+        See torch.Tensor for more details about the `data` argument and additional arguments supplied.
+        """
+        self.atoms = atoms
+
+    @classmethod
+    def make(cls, atoms:list, M:torch.Tensor | torch.Size):
+        R = cls(atoms, data=M)
+        return R
 
     # ---- Operations ----------------------------------------------------------------------------------------
 

--- a/python/src/ptens/ptensor0.py
+++ b/python/src/ptens/ptensor0.py
@@ -1,14 +1,14 @@
 #
-# This file is part of ptens, a C++/CUDA library for permutation 
-# equivariant message passing. 
-#  
+# This file is part of ptens, a C++/CUDA library for permutation
+# equivariant message passing.
+#
 # Copyright (c) 2023, Imre Risi Kondor
 #
-# This source code file is subject to the terms of the noncommercial 
-# license distributed with cnine in the file LICENSE.TXT. Commercial 
-# use is prohibited. All redistributed versions of this file (in 
-# original or modified form) must retain this copyright notice and 
-# must be accompanied by a verbatim copy of the license. 
+# This source code file is subject to the terms of the noncommercial
+# license distributed with cnine in the file LICENSE.TXT. Commercial
+# use is prohibited. All redistributed versions of this file (in
+# original or modified form) must retain this copyright notice and
+# must be accompanied by a verbatim copy of the license.
 #
 #
 
@@ -21,47 +21,39 @@ from ptens.ptensor import ptensor
 class ptensor0(ptensor):
 
     @classmethod
-    def make(self,atoms,M):
-        R=ptensor0(M)
-        R.atoms=atoms
-        return R
+    def zeros(cls, _atoms, _nc, device='cpu'):
+        return cls.make(_atoms,torch.zeros([_nc],device=device))
 
     @classmethod
-    def zeros(self, _atoms, _nc, device='cpu'):
-        return self.make(_atoms,torch.zeros([_nc],device=device))
+    def randn(cls, _atoms, _nc, device='cpu'):
+        return cls.make(_atoms,torch.randn([_nc],device=device))
 
     @classmethod
-    def randn(self, _atoms, _nc, device='cpu'):
-        return self.make(_atoms,torch.randn([_nc],device=device))
-
-    @classmethod
-    def sequential(self,atoms,nc,device='cpu'):
+    def sequential(cls,atoms,nc,device='cpu'):
         assert isinstance(nc,int)
-        return self.make(atoms,torch.tensor([i for i in range (0,nc)],
+        return cls.make(atoms,torch.tensor([i for i in range (0,nc)],
                                             dtype=torch.float,device=device))
 
     @classmethod
-    def from_tensor(self, _atoms, M):
-        return self.make(_atoms,M)
+    def from_tensor(cls, _atoms, M):
+        return cls.make(_atoms,M)
 
     def backend(self):
         return pb.ptensor0.view(self.atoms,self)
-    
+
 
     # ----- Access -------------------------------------------------------------------------------------------
 
-
     def getd(self):
         return 1
-    
+
     def get_nc(self):
         return self.size(0)
-    
+
 
     # ---- Linmaps -------------------------------------------------------------------------------------------
-    
 
-    @classmethod
+
     def linmaps(self,x):
         if isinstance(x,ptensor0):
             return x

--- a/python/src/ptens/ptensor1.py
+++ b/python/src/ptens/ptensor1.py
@@ -1,14 +1,14 @@
 #
-# This file is part of ptens, a C++/CUDA library for permutation 
-# equivariant message passing. 
-#  
+# This file is part of ptens, a C++/CUDA library for permutation
+# equivariant message passing.
+#
 # Copyright (c) 2023, Imre Risi Kondor
 #
-# This source code file is subject to the terms of the noncommercial 
-# license distributed with cnine in the file LICENSE.TXT. Commercial 
-# use is prohibited. All redistributed versions of this file (in 
-# original or modified form) must retain this copyright notice and 
-# must be accompanied by a verbatim copy of the license. 
+# This source code file is subject to the terms of the noncommercial
+# license distributed with cnine in the file LICENSE.TXT. Commercial
+# use is prohibited. All redistributed versions of this file (in
+# original or modified form) must retain this copyright notice and
+# must be accompanied by a verbatim copy of the license.
 #
 #
 
@@ -19,12 +19,6 @@ from ptens.ptensor import ptensor
 
 
 class ptensor1(ptensor):
-
-    @classmethod
-    def make(self,atoms,M):
-        R=ptensor1(M)
-        R.atoms=atoms
-        return R
 
     @classmethod
     def zeros(self,atoms,_nc,device='cpu'):
@@ -53,13 +47,13 @@ class ptensor1(ptensor):
 
     def getd(self):
         return self.size(0)
-    
+
     def get_nc(self):
         return self.size(1)
-    
+
 
     # ---- Linmaps -------------------------------------------------------------------------------------------
-    
+
 
     @classmethod
     def linmaps(self,x):
@@ -119,5 +113,3 @@ class ptensor1(ptensor):
 #     def __deepcopy__(self, memo):
 #         print("deep copied")
 #         return self.__class__(copy.deepcopy(self.data, memo))
-
-

--- a/python/src/ptens/ptensor2.py
+++ b/python/src/ptens/ptensor2.py
@@ -1,14 +1,14 @@
 #
-# This file is part of ptens, a C++/CUDA library for permutation 
-# equivariant message passing. 
-#  
+# This file is part of ptens, a C++/CUDA library for permutation
+# equivariant message passing.
+#
 # Copyright (c) 2023, Imre Risi Kondor
 #
-# This source code file is subject to the terms of the noncommercial 
-# license distributed with cnine in the file LICENSE.TXT. Commercial 
-# use is prohibited. All redistributed versions of this file (in 
-# original or modified form) must retain this copyright notice and 
-# must be accompanied by a verbatim copy of the license. 
+# This source code file is subject to the terms of the noncommercial
+# license distributed with cnine in the file LICENSE.TXT. Commercial
+# use is prohibited. All redistributed versions of this file (in
+# original or modified form) must retain this copyright notice and
+# must be accompanied by a verbatim copy of the license.
 #
 #
 
@@ -21,28 +21,22 @@ from ptens.ptensor import ptensor
 class ptensor2(ptensor):
 
     @classmethod
-    def make(self,atoms,M):
-        R=ptensor2(M)
-        R.atoms=atoms
-        return R
+    def zeros(cls,atoms,_nc,device='cpu'):
+        return cls.make(atoms,torch.zeros([len(atoms),len(atoms),_nc],device=device))
 
     @classmethod
-    def zeros(self,atoms,_nc,device='cpu'):
-        return self.make(atoms,torch.zeros([len(atoms),len(atoms),_nc],device=device))
+    def randn(cls,atoms,_nc,device='cpu'):
+        return cls.make(atoms,torch.randn([len(atoms),len(atoms),_nc],device=device))
 
     @classmethod
-    def randn(self,atoms,_nc,device='cpu'):
-        return self.make(atoms,torch.randn([len(atoms),len(atoms),_nc],device=device))
-
-    @classmethod
-    def sequential(self,atoms,nc,device='cpu'):
+    def sequential(cls,atoms,nc,device='cpu'):
         assert isinstance(nc,int)
-        return self.make(atoms,torch.tensor([i for i in range (0,len(atoms)*len(atoms)*nc)],
+        return cls.make(atoms,torch.tensor([i for i in range (0,len(atoms)*len(atoms)*nc)],
                                             dtype=torch.float,device=device).reshape(len(atoms),len(atoms),nc))
 
     @classmethod
-    def from_tensor(self, atoms, M):
-        return self.make(atoms,M)
+    def from_tensor(cls, atoms, M):
+        return cls.make(atoms,M)
 
     def backend(self):
         return pb.ptensor2.view(self.atoms,self)
@@ -53,13 +47,13 @@ class ptensor2(ptensor):
 
     def getd(self):
         return self.size(0)
-    
+
     def get_nc(self):
         return self.size(2)
-    
+
 
     # ---- Linmaps -------------------------------------------------------------------------------------------
-    
+
 
     @classmethod
     def linmaps(self,x):


### PR DESCRIPTION
Ok, so you were right to wonder about `__new__` and `__init__`.

`torch.Tensors` are special in the sense that they handle memory allocation i.e. `device` vs `host` memory for example.
So we are overloading the `__new__` from torch tensor to preserve the memory allocation structure.

`torch.Tensor` explicitly dissuades users from using constructions with `__init__`. I dug some and the main argument is that is more like the design of `numpy` arrays.

I still provide one for P-Tensors though, mostly because it allows us to enforce Ptensors being instantiated only if `atoms` are provided.
I think that makes sense.

This also allows me to move the factory function `make` into the base class.

Next steps if you are OK with this one.

1. Making `ptensor` an abstract base class.
2. introducing more type hints.
3. Move parts of the docs into the code. (and activate 

**WARNING**
Type hints. with python version 3.9 type hints got much sleeker: https://peps.python.org/pep-0585/
I am using these at the moment. So that limits our minimum version for python.
If you don't like it, I can revert it or use the older syntax.

