### PR TITLE
Fix unrolling args

### DIFF
--- a/python/src/ptens/batched_subgraphlayer0.py
+++ b/python/src/ptens/batched_subgraphlayer0.py
@@ -87,7 +87,7 @@ class batched_subgraphlayer0(p.subgraphlayer,p.batched_ptensorlayer0):
     @classmethod
     def gather(self,S,x,*args):
         atoms=x.G.subgraphs(S)
-        return batched_subgraphlayer0(x.G,x.S,atoms,super().gather(atoms,x,args))
+        return batched_subgraphlayer0(x.G,x.S,atoms,super().gather(atoms,x,*args))
 
 
     # ---- I/O ----------------------------------------------------------------------------------------------

--- a/python/src/ptens/batched_subgraphlayer1.py
+++ b/python/src/ptens/batched_subgraphlayer1.py
@@ -87,7 +87,7 @@ class batched_subgraphlayer1(p.subgraphlayer,p.batched_ptensorlayer1):
     @classmethod
     def gather(self,S,x,*args):
         atoms=x.G.subgraphs(S)
-        return batched_subgraphlayer1(x.G,x.S,atoms,super().gather(atoms,x,args))
+        return batched_subgraphlayer1(x.G,x.S,atoms,super().gather(atoms,x,*args))
 
 
     # ---- I/O ----------------------------------------------------------------------------------------------

--- a/python/src/ptens/subgraphlayer0.py
+++ b/python/src/ptens/subgraphlayer0.py
@@ -75,7 +75,7 @@ class subgraphlayer0(p.subgraphlayer,ptensorlayer0):
     @classmethod
     def gather(self,S,x,*args):
         atoms=x.G.subgraphs(S)
-        return subgraphlayer0(x.G,x.S,atoms,super().gather(atoms,x,args))
+        return subgraphlayer0(x.G,x.S,atoms,super().gather(atoms,x,*args))
 
 
     # ---- I/O ----------------------------------------------------------------------------------------------

--- a/python/src/ptens/subgraphlayer1.py
+++ b/python/src/ptens/subgraphlayer1.py
@@ -80,7 +80,7 @@ class subgraphlayer1(p.subgraphlayer,ptensorlayer1):
     @classmethod
     def gather(self,S,x,*args):
         atoms=x.G.subgraphs(S)
-        return subgraphlayer1(x.G,x.S,atoms,super().gather(atoms,x,args))
+        return subgraphlayer1(x.G,x.S,atoms,super().gather(atoms,x,*args))
 
 
     # ---- Other -------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is just a typo in some `subgraphlayer.gather` calls the optional arguments were not unrolled correctly, which leads to a wrong overlap map.

I will mark the instances.

And when checking for completeness, I noticed that a couple place could have the same optional argument practice, but it isn't implemented.

I will mark with comments interesting parts.
Unfortunately, my editor touch a bunch of unrelated white spaces. (deleting trailing white spaces.) 