### PR TITLE
Add `torch.nn.functional.linear` to the covariant functions.

### DIFF
--- a/python/src/ptens/ptensorlayer.py
+++ b/python/src/ptens/ptensorlayer.py
@@ -19,7 +19,7 @@ import ptens_base as pb
 
 class ptensorlayer(torch.Tensor):
 
-    covariant_functions=[torch.Tensor.to,torch.Tensor.add,torch.Tensor.sub,torch.relu]
+    covariant_functions=[torch.Tensor.to,torch.Tensor.add,torch.Tensor.sub,torch.relu,torch.nn.functional.linear]
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):

--- a/python/src/ptens/subgraphlayer.py
+++ b/python/src/ptens/subgraphlayer.py
@@ -17,7 +17,7 @@ import ptens_base as pb
 
 class subgraphlayer(torch.Tensor):
 
-    covariant_functions=[torch.Tensor.to,torch.Tensor.add,torch.Tensor.sub,torch.relu]
+    covariant_functions=[torch.Tensor.to,torch.Tensor.add,torch.Tensor.sub,torch.relu,torch.nn.functional.linear]
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):


### PR DESCRIPTION
This add `torch.nn.functinal.linear` to the covariant functions of `ptensorlayer` and `subgraphlayer`.

This allows them to be passed through a `torch.nn.Linear` module and remain of the same type.

`torch.nn.functional.linear` is the lowest level C++ implementation that for this.
I think it a low-level merge of matmul and add.