### PR TITLE
Adding missing CUDA source.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -127,6 +127,7 @@ def main():
             '../../cnine/cuda/TensorView_add.cu',
             '../../cnine/cuda/TensorView_assign.cu',
             '../../cnine/cuda/TensorView_inc.cu',
+            '../../cnine/cuda/BlockCsparseMatrix.cu',
             #'../../cnine/cuda/RtensorPackUtils.cu',
             #'../../cnine/cuda/gatherRows.cu',
             '../cuda/Ptensors0.cu',


### PR DESCRIPTION
This adds a missing CUDA source, which is necessary to compile/load with CUDA install.

Goes together with https://github.com/risi-kondor/cnine/pull/10